### PR TITLE
Fix ReproZip citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Mentors: Prof. Victoria Stodden, University of Illinois at Urbana-Champaign
 
 **2**: I. Jimenez, M. Sevilla, N. Watkins, C. Maltzahn, J. Lofstead, K. Mohror, A. Arpaci-Dusseau and R. Arpaci-Dusseau. (2017). The Popper Convention: Making Reproducible Systems Evaluation Practical. IEEE International Parallel and Distributed Processing Symposium Workshops (IPDPSW), 1561–70. https://doi.org/10.1109/IPDPSW.2017.157.
 
-**3**: F. Chirigati, D. Shasha and J. Freire, (2013). ReproZip: Using Provenance to Support Computational Reproducibility, 5th USENIX Workshop on the Theory and Practice of Provenance.
+**3**: ReproZip: Computational Reproducibility With Ease, F. Chirigati, R. Rampin, D. Shasha, and J. Freire. In Proceedings of the 2016 ACM SIGMOD International Conference on Management of Data (SIGMOD), pp. 2085-2088, 2016.
 
 **4**: A. P Davison, M Mattioni, D Samarkanov, B Tele'nczuk. (2014). Sumatra: A Toolkit for Reproducible Research. In Implementing Reproducible Research, Eds: Stodden, V and Leisch, F and and Chapman, R D Peng, pp.57-79
 


### PR DESCRIPTION
Hi!

This paper describe a totally different version of the system, that was completely rewritten in 2013. It didn't use ptrace, Docker or Vagrant.

We have the correct citation up on [the website](https://www.reprozip.org/about.html#cite) and [the repository](https://github.com/VIDA-NYU/reprozip/blob/1.0.x/CITATION.txt). We're really not sure why people keep getting our citation wrong. Do you mind sharing where you got this one?

Thanks